### PR TITLE
Remove the file watch on .clang-tidy

### DIFF
--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -25,7 +25,7 @@ class ConfigFileWatcher {
       this.databaseWatcher = vscode.workspace.createFileSystemWatcher(
           '{' +
           vscode.workspace.workspaceFolders.map(f => f.uri.fsPath).join(',') +
-          '}/{build/compile_commands.json,compile_commands.json,compile_flags.txt,.clang-tidy}');
+          '}/{build/compile_commands.json,compile_commands.json,compile_flags.txt}');
       this.context.subscriptions.push(this.databaseWatcher.onDidChange(
           this.handleConfigFilesChanged.bind(this)));
       this.context.subscriptions.push(this.databaseWatcher.onDidCreate(


### PR DESCRIPTION
Restarting the server when this file changes doesn't make that much sense.
There can be .clang-tidy files in sub directories(and parent directories) that wont be watched so having the server restart when only the base directory configuration changes leads to non deterministic behaviour.
Ensuring clang-tidy configurations are up to date should be done on the clangd server instead. This could be done in a similar way to how the config files are cached but validated against modification time when accessed.
Going this route will also work for other editors that use clangd.